### PR TITLE
[WORK-3529] improve: onpress & animation preview image

### DIFF
--- a/lib/src/delegates/asset_picker_builder_delegate.dart
+++ b/lib/src/delegates/asset_picker_builder_delegate.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 import 'dart:typed_data' as typed_data;
 import 'dart:ui' as ui;
 
-import 'package:extended_image/extended_image.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
@@ -15,6 +14,7 @@ import 'package:flutter_phosphor_icons/flutter_phosphor_icons.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photo_manager_image_provider/photo_manager_image_provider.dart';
 import 'package:provider/provider.dart';
+import 'package:wechat_assets_picker/src/delegates/asset_picker_preview.dart';
 import 'package:wechat_picker_library/wechat_picker_library.dart';
 
 import '../constants/constants.dart';
@@ -2094,91 +2094,14 @@ class DefaultAssetPickerBuilderDelegate
         builder: (_, DefaultAssetPickerProvider p, __) {
           final int index = p.selectedAssets.indexOf(asset);
           final bool selected = index != -1;
-          return InkWell(
-            onTap: () {
-              selectAsset(context, asset, index, selected);
-            },
-            onLongPress: () {
-              if (asset.type == AssetType.image) {
-                showDialog(
-                  context: context,
-                  barrierDismissible: true,
-                  barrierColor: Colors.black54,
-                  builder: (BuildContext context) {
-                    return GestureDetector(
-                      behavior: HitTestBehavior.opaque,
-                      onTap: () => Navigator.of(context).pop(),
-                      child: Center(
-                        child: Dialog(
-                          elevation: 0,
-                          backgroundColor: Colors.transparent,
-                          insetPadding: EdgeInsets.zero,
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(8),
-                            child: Container(
-                              constraints: BoxConstraints(
-                                maxHeight:
-                                    MediaQuery.sizeOf(context).height * 0.8,
-                              ),
-                              child: ExtendedImage(
-                                image: AssetEntityImageProvider(
-                                  asset,
-                                  isOriginal: true,
-                                ),
-                                fit: BoxFit.contain,
-                                loadStateChanged: (state) =>
-                                    switch (state.extendedImageLoadState) {
-                                  LoadState.loading => const SizedBox(
-                                      width: 40,
-                                      height: 40,
-                                      child: Center(
-                                          child: CircularProgressIndicator(
-                                              color: Colors.cyanAccent,
-                                              strokeWidth: 2))),
-                                  LoadState.completed => state.completedWidget,
-                                  LoadState.failed =>
-                                    const Icon(PhosphorIcons.warning_circle)
-                                },
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    );
-                  },
-                );
-              }
-            },
-            child: Container(
-              color: selected
-                  ? Color(0xffFFFFFF).withOpacity(0.5)
-                  : Colors.transparent,
-              child: selected && !isSingleAssetMode
-                  ? Container(
-                      color: Colors.transparent,
-                      child: Center(
-                        child: Container(
-                          width: 28,
-                          height: 28,
-                          decoration: BoxDecoration(
-                              color: Color(0xFF05AABD),
-                              borderRadius: BorderRadius.circular(20)),
-                          child: Center(
-                            child: Text(
-                              '${index + 1}',
-                              style: TextStyle(
-                                color: Color(0xffFFFFFF),
-                                fontWeight: FontWeight.w500,
-                                fontSize: 17,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    )
-                  : const SizedBox.shrink(),
-            ),
-          );
+          return AssetPickerPreview(
+              asset: asset,
+              index: index,
+              selected: selected,
+              isSingleAssetMode: isSingleAssetMode,
+              onTap: () {
+                selectAsset(context, asset, index, selected);
+              });
         },
       ),
     );

--- a/lib/src/delegates/asset_picker_preview.dart
+++ b/lib/src/delegates/asset_picker_preview.dart
@@ -1,0 +1,203 @@
+import 'dart:async';
+
+import 'package:extended_image/extended_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_phosphor_icons/flutter_phosphor_icons.dart';
+import 'package:wechat_assets_picker/wechat_assets_picker.dart';
+
+class AssetPickerPreview extends StatefulWidget {
+  const AssetPickerPreview({
+    super.key,
+    required this.asset,
+    required this.index,
+    required this.selected,
+    required this.isSingleAssetMode,
+    required this.onTap,
+  });
+
+  final AssetEntity asset;
+  final int index;
+  final bool selected;
+  final bool isSingleAssetMode;
+  final VoidCallback onTap;
+
+  @override
+  State<AssetPickerPreview> createState() => _AssetPickerPreviewState();
+}
+
+class _AssetPickerPreviewState extends State<AssetPickerPreview>
+    with SingleTickerProviderStateMixin {
+  Timer? _pressTimer;
+  bool _pressed = false;
+  OverlayEntry? _overlayEntry;
+
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 220),
+      reverseDuration: const Duration(milliseconds: 180),
+    );
+
+    _opacity = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOutCubic,
+      reverseCurve: Curves.easeInCubic,
+    );
+
+    _scale = Tween<double>(begin: 0.95, end: 1).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: Curves.easeOutCubic,
+        reverseCurve: Curves.easeInCubic,
+      ),
+    );
+  }
+
+  void _showPreview() {
+    if (_pressed || widget.asset.type != AssetType.image) return;
+
+    _pressed = true;
+    HapticFeedback.lightImpact();
+
+    final overlay = Overlay.of(context, rootOverlay: true);
+
+    _overlayEntry = OverlayEntry(
+      builder: (_) {
+        return Positioned.fill(
+          child: IgnorePointer(
+            child: FadeTransition(
+              opacity: _opacity,
+              child: Container(
+                color: Colors.black54,
+                alignment: Alignment.center,
+                child: ScaleTransition(
+                  scale: _scale,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        maxHeight: MediaQuery.of(context).size.height * 0.8,
+                      ),
+                      child: ExtendedImage(
+                        image: AssetEntityImageProvider(
+                          widget.asset,
+                          isOriginal: true,
+                        ),
+                        fit: BoxFit.contain,
+                        loadStateChanged: (state) =>
+                            switch (state.extendedImageLoadState) {
+                          LoadState.loading => const SizedBox(
+                              width: 40,
+                              height: 40,
+                              child: Center(
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.cyanAccent,
+                                ),
+                              ),
+                            ),
+                          LoadState.completed => state.completedWidget,
+                          LoadState.failed =>
+                            const Icon(PhosphorIcons.warning_circle),
+                        },
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    overlay.insert(_overlayEntry!);
+    _controller.forward(from: 0);
+  }
+
+  Future<void> _hidePreview() async {
+    _pressTimer?.cancel();
+    _pressTimer = null;
+
+    if (!_pressed) return;
+    _pressed = false;
+
+    await _controller.reverse();
+    _overlayEntry?.remove();
+    _overlayEntry = null;
+  }
+
+  void _onTapDown() {
+    _pressTimer = Timer(
+      const Duration(milliseconds: 120),
+      _showPreview,
+    );
+  }
+
+  void _onTapUp() {
+    _pressTimer?.cancel();
+
+    if (_pressed) {
+      _hidePreview();
+    } else {
+      widget.onTap();
+    }
+  }
+
+  void _onTapCancel() {
+    _pressTimer?.cancel();
+    _hidePreview();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapDown: (_) => _onTapDown(),
+      onTapUp: (_) => _onTapUp(),
+      onTapCancel: _onTapCancel,
+      child: Container(
+        color: widget.selected
+            ? const Color(0xffFFFFFF).withOpacity(0.5)
+            : Colors.transparent,
+        child: widget.selected && !widget.isSingleAssetMode
+            ? Center(
+                child: Container(
+                  width: 28,
+                  height: 28,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF05AABD),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  alignment: Alignment.center,
+                  child: Text(
+                    '${widget.index + 1}',
+                    style: const TextStyle(
+                      color: Color(0xffFFFFFF),
+                      fontWeight: FontWeight.w500,
+                      fontSize: 17,
+                    ),
+                  ),
+                ),
+              )
+            : const SizedBox.shrink(),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _pressTimer?.cancel();
+    _controller.dispose();
+    _overlayEntry?.remove();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
- When the user long-presses an image, a preview is shown; releasing the finger hides the preview.
- Add animations to make the interaction smoother

https://github.com/user-attachments/assets/9040eb8b-ede1-4450-ad05-4549ef1049ff

